### PR TITLE
feat: union props

### DIFF
--- a/packages-private/dts-test/setupHelpers.test-d.ts
+++ b/packages-private/dts-test/setupHelpers.test-d.ts
@@ -207,6 +207,77 @@ describe('defineProps w/ generic type declaration + withDefaults', <T extends
   expectType<boolean>(res.bool)
 })
 
+describe('defineProps w/union type', () => {
+  type PP =
+    | {
+        type: 'text'
+        mm: string
+      }
+    | {
+        type: 'number'
+        mm: number | null
+      }
+
+  const res = defineProps<PP>()
+  expectType<string | number | null>(res.mm)
+
+  if (res.type === 'text') {
+    expectType<string>(res.mm)
+  }
+
+  if (res.type === 'number') {
+    expectType<number | null>(res.mm)
+  }
+})
+
+describe('withDefaults w/ union type', () => {
+  type PP =
+    | {
+        type?: 'text'
+        mm: string
+      }
+    | {
+        type?: 'number'
+        mm: number | null
+      }
+
+  const res = withDefaults(defineProps<PP>(), {
+    type: 'text',
+  })
+
+  if (res.type && res.type === 'text') {
+    expectType<string>(res.mm)
+  }
+
+  if (res.type === 'number') {
+    expectType<number | null>(res.mm)
+  }
+})
+
+describe('withDefaults w/ generic union type', <T extends
+  | string
+  | number>() => {
+  type PP =
+    | {
+        tt?: 'a'
+        mm: T
+      }
+    | {
+        tt?: 'b'
+        mm: T[]
+      }
+
+  const res = withDefaults(defineProps<PP>(), {
+    tt: 'a',
+  })
+
+  if (res.tt === 'a') {
+    expectType<T>(res.mm)
+  } else {
+    expectType<T[]>(res.mm)
+  }
+})
+
 describe('withDefaults w/ boolean type', () => {
   const res1 = withDefaults(
     defineProps<{

--- a/packages-private/dts-test/setupHelpers.test-d.ts
+++ b/packages-private/dts-test/setupHelpers.test-d.ts
@@ -230,6 +230,28 @@ describe('defineProps w/union type', () => {
   }
 })
 
+describe('defineProps w/distributive union type', () => {
+  type PP =
+    | {
+        type1: 'text'
+        mm1: string
+      }
+    | {
+        type2: 'number'
+        mm2: number | null
+      }
+
+  const res = defineProps<PP>()
+
+  if ('type1' in res) {
+    expectType<string>(res.mm1)
+  }
+
+  if ('type2' in res) {
+    expectType<number | null>(res.mm2)
+  }
+})
+
 describe('withDefaults w/ union type', () => {
   type PP =
     | {

--- a/packages/compiler-sfc/__tests__/compileScript/__snapshots__/defineProps.spec.ts.snap
+++ b/packages/compiler-sfc/__tests__/compileScript/__snapshots__/defineProps.spec.ts.snap
@@ -93,6 +93,68 @@ return { foo }
 })"
 `;
 
+exports[`defineProps > discriminated union 1`] = `
+"import { defineComponent as _defineComponent } from 'vue'
+
+export default /*@__PURE__*/_defineComponent({
+  props: {
+    tag: { type: [String, Number], required: true, union: [['d1'], ['d2']] },
+    d1: { type: Number, required: true, union: ['tag'] },
+    d2: { type: String, required: true, union: ['tag'] }
+  },
+  setup(__props: any, { expose: __expose }) {
+  __expose();
+
+      const props = __props;
+    
+return { props }
+}
+
+})"
+`;
+
+exports[`defineProps > distributive union w/ conditional keys 1`] = `
+"import { defineComponent as _defineComponent } from 'vue'
+
+export default /*@__PURE__*/_defineComponent({
+  props: {
+    a: { type: String, required: false, union: ['b'] },
+    b: { type: Number, required: true, union: ['a'] },
+    c: { type: Number, required: true, union: ['d'] },
+    d: { type: String, required: false, union: ['c'] }
+  },
+  setup(__props: any, { expose: __expose }) {
+  __expose();
+
+      const props = __props;
+    
+return { props }
+}
+
+})"
+`;
+
+exports[`defineProps > distributive union with boolean keys 1`] = `
+"import { defineComponent as _defineComponent } from 'vue'
+
+export default /*@__PURE__*/_defineComponent({
+  props: {
+    a: { type: String, required: true, union: ['b'] },
+    b: { type: Number, required: true, union: ['a'] },
+    c: { type: Boolean, required: true, union: ['d'] },
+    d: { type: String, required: true, union: ['c'] }
+  },
+  setup(__props: any, { expose: __expose }) {
+  __expose();
+
+      const props = __props;
+    
+return { props }
+}
+
+})"
+`;
+
 exports[`defineProps > should escape names w/ special symbols 1`] = `
 "import { defineComponent as _defineComponent } from 'vue'
 

--- a/packages/compiler-sfc/__tests__/compileScript/defineProps.spec.ts
+++ b/packages/compiler-sfc/__tests__/compileScript/defineProps.spec.ts
@@ -399,6 +399,54 @@ const props = defineProps({ foo: String })
     assertCode(content)
   })
 
+  test('distributive union w/ conditional keys', () => {
+    const { content } = compile(`
+    <script setup lang="ts">
+      const props = withDefaults(defineProps<{
+        a?: string;
+        b: number;
+      } | {
+       c: number;
+       d?: string;
+       }>(), {
+      });
+    </script>
+    `)
+    assertCode(content)
+  })
+
+  test('discriminated union', () => {
+    const { content } = compile(`
+    <script setup lang="ts">
+      const props = withDefaults(defineProps<{
+        tag: string;
+        d1: number;
+      } | {
+        tag: number;
+        d2: string;
+       }>(), {
+      });
+    </script>
+    `)
+    assertCode(content)
+  })
+
+  test('distributive union with boolean keys', () => {
+    const { content } = compile(`
+    <script setup lang="ts">
+      const props = withDefaults(defineProps<{
+        a: string;
+        b: number;
+      } | {
+        c: boolean;
+        d: string;
+      }>(), {
+      });
+    </script>
+    `)
+    assertCode(content)
+  })
+
   // #7111
   test('withDefaults (static) w/ production mode', () => {
     const { content } = compile(

--- a/packages/runtime-core/__tests__/componentProps.spec.ts
+++ b/packages/runtime-core/__tests__/componentProps.spec.ts
@@ -196,12 +196,12 @@ describe('component props', () => {
       c: {
         type: Boolean,
         required: true,
-        union: ['c'],
+        union: ['d'],
       },
       d: {
         type: String,
         required: false,
-        union: ['d'],
+        union: ['c'],
       },
     }
 

--- a/packages/runtime-core/__tests__/componentProps.spec.ts
+++ b/packages/runtime-core/__tests__/componentProps.spec.ts
@@ -166,6 +166,123 @@ describe('component props', () => {
     expect('type check failed for prop "qux"').toHaveBeenWarned()
   })
 
+  test('distributive union props', () => {
+    /**
+     * type Props = {
+     *  a?: string
+     *  b: number
+     *  bb?: number
+     * } | {
+     *  c: boolean
+     *  d?: string
+     * }
+     */
+    const props = {
+      a: {
+        type: String,
+        required: false,
+        union: ['b', 'bb'],
+      },
+      b: {
+        type: Number,
+        required: true,
+        union: ['a', 'bb'],
+      },
+      bb: {
+        type: Number,
+        required: false,
+        union: ['a', 'b'],
+      },
+      c: {
+        type: Boolean,
+        required: true,
+        union: ['c'],
+      },
+      d: {
+        type: String,
+        required: false,
+        union: ['d'],
+      },
+    }
+
+    let proxy: any
+    const Comp = {
+      props,
+      render() {
+        proxy = this
+      },
+    }
+
+    render(
+      h(Comp, {
+        a: 'foo',
+        // b: absent required - should warn
+        // bb: absent not required - should not warn
+        // c: not in active union path - undefined boolean should not default to false - should not warn
+        // d: not in active union path - should not warn
+      }),
+      nodeOps.createElement('div'),
+    )
+
+    expect(proxy.a).toBe('foo')
+    expect('Missing required prop: "b"').toHaveBeenWarned()
+
+    expect('Missing required prop: "c"').not.toHaveBeenWarned()
+    expect('Missing required prop: "d"').not.toHaveBeenWarned()
+  })
+
+  test('discriminated union props', () => {
+    /**
+     * type Props = {
+     *  a: string
+     *  b: number
+     * } | {
+     *  a: string
+     *  c: string
+     * }
+     */
+    const props = {
+      a: {
+        type: [String, Number],
+        required: true,
+        union: [['b'], ['c']],
+      },
+      b: {
+        type: Number,
+        required: true,
+        union: ['a'],
+      },
+      c: {
+        type: Boolean,
+        required: true,
+        union: ['a'],
+      },
+    }
+
+    let proxy: any
+    const Comp = {
+      props,
+      render() {
+        proxy = this
+      },
+    }
+
+    render(
+      h(Comp, {
+        b: 2,
+        // a: absent required - should warn
+        // c: not in active union path - should not warn
+      }),
+      nodeOps.createElement('div'),
+    )
+
+    expect(proxy.b).toBe(2)
+    expect('Missing required prop: "a"').toHaveBeenWarned()
+
+    expect('Missing required prop: "b"').not.toHaveBeenWarned()
+    expect('Missing required prop: "c"').not.toHaveBeenWarned()
+  })
+
   test('default value', () => {
     let proxy: any
     const defaultFn = vi.fn(() => ({ a: 1 }))

--- a/packages/runtime-core/src/apiSetupHelpers.ts
+++ b/packages/runtime-core/src/apiSetupHelpers.ts
@@ -313,9 +313,6 @@ export function defineModel(): any {
 }
 
 type NotUndefined<T> = T extends undefined ? never : T
-type MappedOmit<T, K extends keyof any> = {
-  [P in keyof T as P extends K ? never : P]: T[P]
-}
 
 type InferDefaults<T> = {
   [K in keyof T]?: InferDefault<T, T[K]>
@@ -331,7 +328,7 @@ type PropsWithDefaults<
   T,
   Defaults extends InferDefaults<T>,
   BKeys extends keyof T,
-> = Readonly<MappedOmit<T, keyof Defaults>> & {
+> = Readonly<T> & {
   readonly [K in keyof Defaults as K extends keyof T
     ? K
     : never]-?: K extends keyof T

--- a/packages/runtime-core/src/componentProps.ts
+++ b/packages/runtime-core/src/componentProps.ts
@@ -52,11 +52,17 @@ export type Prop<T, D = T> = PropOptions<T, D> | PropType<T>
 
 type DefaultFactory<T> = (props: Data) => T | null | undefined
 
+type UnionDefinition = string[] | string[][]
+
 export interface PropOptions<T = any, D = T> {
   type?: PropType<T> | true | null
   required?: boolean
   default?: D | DefaultFactory<D> | null | undefined | object
   validator?(value: unknown, props: Data): boolean
+  /**
+   * @internal
+   */
+  union?: UnionDefinition
   /**
    * @internal
    */
@@ -486,7 +492,10 @@ function resolvePropValue(
       }
     }
     // boolean casting
-    if (opt[BooleanFlags.shouldCast]) {
+    if (
+      opt[BooleanFlags.shouldCast] &&
+      (!opt.union || isInActiveUnion(key, opt, props))
+    ) {
       if (isAbsent && !hasDefault) {
         value = false
       } else if (
@@ -498,6 +507,28 @@ function resolvePropValue(
     }
   }
   return value
+}
+
+function isInActiveUnion(
+  key: string,
+  prop: NormalizedProp,
+  props: Data,
+): boolean {
+  const union = prop.union
+  if (!union) {
+    return false
+  }
+  return union.some(u => {
+    return (
+      Object.entries(props)
+        .filter(([k]) => k !== key) // skip current key
+        // check if any key in union is in props
+        .some(
+          ([k, v]) =>
+            (u === k || (Array.isArray(u) && u.includes(k))) && v !== undefined,
+        )
+    )
+  })
 }
 
 const mixinPropsCache = new WeakMap<ConcreteComponent, NormalizedPropsOptions>()
@@ -676,6 +707,11 @@ function validateProp(
   isAbsent: boolean,
 ) {
   const { type, required, validator, skipCheck } = prop
+
+  if (prop.union && !isInActiveUnion(name, prop, props)) {
+    return
+  }
+
   // required!
   if (required && isAbsent) {
     warn('Missing required prop: "' + name + '"')


### PR DESCRIPTION
One of the last missing features from TypeScript support in Vue is the ability to use union types in props with runtime validation. This PR aims to address these limitations and provide a more flexible way to define props.